### PR TITLE
Group all dependencies into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
 
     # Open a new pull request every week, if there are updates available.
     schedule:
-      interval: 'weekly'
-      timezone: 'Europe/Berlin'
+      interval: "weekly"
+      timezone: "Europe/Berlin"
 
     labels:
-      - 'enhancement'
+      - "enhancement"
+
+    # Create one pull request for all dependencies.
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/hono-client/pull/14 and truly ensures a single Dependabot PR per week!