### PR TITLE
Fix `types` export property

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const app = new Hono();
 app.use("*", ronin());
 
 app.get("/", async (c) => {
-  const posts = await c.vars.ronin.get.posts();
+  const posts = await c.var.ronin.get.posts();
   return c.json(posts);
 });
 ```

--- a/package.json
+++ b/package.json
@@ -15,26 +15,16 @@
     "test": "bun test",
     "prepare": "husky"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "repository": "ronin-co/hono-ronin",
   "homepage": "https://github.com/ronin-co/hono-ronin",
-  "keywords": [
-    "ronin",
-    "hono",
-    "client",
-    "database",
-    "orm"
-  ],
+  "keywords": ["ronin", "hono", "client", "database", "orm"],
   "lint-staged": {
-    "**/*": [
-      "bunx @biomejs/biome format --write {./**/*.ts,**.json}"
-    ]
+    "**/*": ["bunx @biomejs/biome format --write {./**/*.ts,**.json}"]
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
This fixes the types exported from this package, which previously were failing because the `package.json`'s `exports` property had the `.` export pointing to a file that does not exist.

Additionally this both formats the `package.json` file & updates the `README.md` to fix a typo in the example code snippet.