### PR TITLE
Fixed `ronin` middleware options derived from `ronin` client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export const ronin = (options: QueryHandlerOptions = {}) =>
     const userOptions = typeof options === "function" ? options() : options;
     if (userOptions.token) {
       console.warn(
-        "The `token` option is ignored in favour of `c.env.RONIN_TOKEN` when using the `ronin` middleware",
+        "The `token` option is ignored in favor of `c.env.RONIN_TOKEN` when using the `ronin` middleware.",
       );
 
       // biome-ignore lint/performance/noDelete: We're only deleting the property if it exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ type Env = {
   Variables: Variables;
 };
 
-type QueryHandlerOptions = Omit<Parameters<typeof createFactory>[0], "token">;
+type QueryHandlerOptions = Parameters<typeof createFactory>[0];
 
 /**
  * Create a Hono middleware that injects a RONIN client into the Hono context variables.
@@ -48,9 +48,19 @@ export const ronin = (options: QueryHandlerOptions = {}) =>
     if (!c.env.RONIN_TOKEN)
       throw new Error("Missing `RONIN_TOKEN` in environment variables");
 
+    const userOptions = typeof options === "function" ? options() : options;
+    if (userOptions.token) {
+      console.warn(
+        "The `token` option is ignored in favour of `c.env.RONIN_TOKEN` when using the `ronin` middleware",
+      );
+
+      // biome-ignore lint/performance/noDelete: We're only deleting the property if it exists
+      delete userOptions.token;
+    }
+
     const client = createFactory({
       token: c.env.RONIN_TOKEN,
-      ...options,
+      ...userOptions,
     });
 
     c.set("ronin", client);

--- a/tests/integration/index.test.ts
+++ b/tests/integration/index.test.ts
@@ -59,7 +59,7 @@ describe("use `ronin` middleware", () => {
     expect(json).toHaveLength(0);
   });
 
-  it("with a custom options", async () => {
+  it("with a custom options (object)", async () => {
     const app = factory
       .createApp()
       .use(
@@ -99,5 +99,76 @@ describe("use `ronin` middleware", () => {
     expect(json).toBeDefined();
     expect(json).toBeInstanceOf(Array);
     expect(json).toHaveLength(1);
+  });
+
+  it("with a custom options (function)", async () => {
+    const app = factory
+      .createApp()
+      .use(
+        "*",
+        ronin(() => ({
+          hooks: {
+            user: {
+              beforeGet: (query) => {
+                query.limitedTo = 1;
+                return query;
+              },
+            },
+          },
+          asyncContext: new AsyncLocalStorage(),
+        })),
+      )
+      .get("/", async (c) => {
+        expect(c.var.ronin).toBeDefined();
+
+        const users = await c.var.ronin.get.users();
+
+        expect(users).toBeDefined();
+        expect(users).toBeInstanceOf(Array);
+
+        return c.json(users);
+      });
+
+    const response = await testClient(app, {
+      RONIN_TOKEN: import.meta.env.RONIN_TOKEN,
+    }).index.$get();
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+
+    expect(json).toBeDefined();
+    expect(json).toBeInstanceOf(Array);
+    expect(json).toHaveLength(1);
+  });
+
+  it("with a ignored `token` property", async () => {
+    const app = factory
+      .createApp()
+      .use("*", ronin({ token: crypto.randomUUID() }))
+      .get("/", async (c) => {
+        expect(c.var.ronin).toBeDefined();
+
+        const users = await c.var.ronin.get.users();
+
+        expect(users).toBeDefined();
+        expect(users).toBeInstanceOf(Array);
+
+        return c.json(users);
+      });
+
+    const response = await testClient(app, {
+      RONIN_TOKEN: import.meta.env.RONIN_TOKEN,
+    }).index.$get();
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+
+    expect(json).toBeDefined();
+    expect(json).toBeInstanceOf(Array);
+    expect(json).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This PR updates the way that the types are extracted from the `ronin` package & passed to the `ronin()` middleware. This includes now supporting options as a function.

Additionally I have added a check to print a console warning if a `token` property is provided anyway & then delete it from the options object passed to the `ronin` client.