### PR TITLE
Error upon `token` option instead of logging

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -81,17 +81,5 @@
     "clientKind": "git",
     "defaultBranch": "main",
     "enabled": true
-  },
-  "overrides": [
-    {
-      "include": ["tests/**"],
-      "linter": {
-        "rules": {
-          "performance": {
-            "useTopLevelRegex": "off"
-          }
-        }
-      }
-    }
-  ]
+  }
 }

--- a/biome.json
+++ b/biome.json
@@ -48,8 +48,7 @@
         "all": true,
 
         "noBarrelFile": "off",
-        "noReExportAll": "off",
-        "noDelete": "off"
+        "noReExportAll": "off"
       },
       "security": { "all": true },
       "style": {

--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,8 @@
         "all": true,
 
         "noBarrelFile": "off",
-        "noReExportAll": "off"
+        "noReExportAll": "off",
+        "noDelete": "off"
       },
       "security": { "all": true },
       "style": {
@@ -80,5 +81,17 @@
     "clientKind": "git",
     "defaultBranch": "main",
     "enabled": true
-  }
+  },
+  "overrides": [
+    {
+      "include": ["tests/**"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "useTopLevelRegex": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,14 +48,10 @@ export const ronin = (options: QueryHandlerOptions = {}) =>
     if (!c.env.RONIN_TOKEN)
       throw new Error('Missing `RONIN_TOKEN` in environment variables');
 
-    const userOptions = typeof options === 'function' ? options() : options;
-    if (userOptions.token) {
-      console.warn(
-        'The `token` option is ignored in favor of `c.env.RONIN_TOKEN` when using the `ronin` middleware.',
-      );
+    const { token: userToken, ...userOptions } =
+      typeof options === 'function' ? options() : options;
 
-      delete userOptions.token;
-    }
+    if (userToken) throw new Error('No `token` option is allowed');
 
     const client = createFactory({
       token: c.env.RONIN_TOKEN,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,13 +45,18 @@ type QueryHandlerOptions = Parameters<typeof createFactory>[0];
  */
 export const ronin = (options: QueryHandlerOptions = {}) =>
   createMiddleware<Env>(async (c, next) => {
-    if (!c.env.RONIN_TOKEN)
-      throw new Error('Missing `RONIN_TOKEN` in environment variables');
+    if (!c.env.RONIN_TOKEN) {
+      throw new Error(
+        'A `RONIN_TOKEN` environment variable must be provided for the RONIN middleware',
+      );
+    }
 
     const { token: userToken, ...userOptions } =
       typeof options === 'function' ? options() : options;
 
-    if (userToken) throw new Error('No `token` option is allowed');
+    if (userToken) {
+      throw new Error('The RONIN middleware does not support a `token` option');
+    }
 
     const client = createFactory({
       token: c.env.RONIN_TOKEN,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -151,7 +151,8 @@ describe('use `ronin` middleware', () => {
     }).index.$get();
 
     expect(receivedError).toMatchObject({
-      message: 'Missing `RONIN_TOKEN` in environment variables',
+      message:
+        'A `RONIN_TOKEN` environment variable must be provided for the RONIN middleware',
     });
   });
 
@@ -178,7 +179,7 @@ describe('use `ronin` middleware', () => {
     }).index.$get();
 
     expect(receivedError).toMatchObject({
-      message: 'No `token` option is allowed',
+      message: 'The RONIN middleware does not support a `token` option',
     });
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -13,33 +13,6 @@ import.meta.env.RONIN_TOKEN = 'secret-token';
 describe('use `ronin` middleware', () => {
   const factory = createFactory<{ Bindings: Bindings; Variables: Variables }>();
 
-  it('with a missing `RONIN_TOKEN`', async () => {
-    let receivedError: Error | undefined;
-
-    const app = factory
-      .createApp()
-      .use('*', ronin({ fetch: fetcher }))
-      .get('/', async (c) => {
-        expect(c.var.ronin).toBeDefined();
-
-        const posts = (await c.var.ronin.get.blogPosts()) as Array<unknown>;
-
-        return c.json(posts);
-      })
-      .onError((err) => {
-        receivedError = err;
-        return new Response();
-      });
-
-    await testClient(app, {
-      RONIN_TOKEN: null,
-    }).index.$get();
-
-    expect(receivedError).toMatchObject({
-      message: 'Missing `RONIN_TOKEN` in environment variables',
-    });
-  });
-
   it('with default options', async () => {
     const app = factory
       .createApp()
@@ -155,32 +128,57 @@ describe('use `ronin` middleware', () => {
     expect(json).toHaveLength(1);
   });
 
-  it('with a ignored `token` option', async () => {
+  it('with a missing `RONIN_TOKEN`', async () => {
+    let receivedError: Error | undefined;
+
+    const app = factory
+      .createApp()
+      .use('*', ronin({ fetch: fetcher }))
+      .get('/', async (c) => {
+        expect(c.var.ronin).toBeDefined();
+
+        const posts = (await c.var.ronin.get.blogPosts()) as Array<unknown>;
+
+        return c.json(posts);
+      })
+      .onError((err) => {
+        receivedError = err;
+        return new Response();
+      });
+
+    await testClient(app, {
+      RONIN_TOKEN: null,
+    }).index.$get();
+
+    expect(receivedError).toMatchObject({
+      message: 'Missing `RONIN_TOKEN` in environment variables',
+    });
+  });
+
+  it('with a `token` option', async () => {
+    let receivedError: Error | undefined;
+
     const app = factory
       .createApp()
       .use('*', ronin({ fetch: fetcher, token: crypto.randomUUID() }))
       .get('/', async (c) => {
         expect(c.var.ronin).toBeDefined();
 
-        const users = await c.var.ronin.get.users();
+        const posts = (await c.var.ronin.get.blogPosts()) as Array<unknown>;
 
-        expect(users).toBeDefined();
-        expect(users).toBeInstanceOf(Array);
-
-        return c.json(users);
+        return c.json(posts);
+      })
+      .onError((err) => {
+        receivedError = err;
+        return new Response();
       });
 
-    const response = await testClient(app, {
+    await testClient(app, {
       RONIN_TOKEN: import.meta.env.RONIN_TOKEN,
     }).index.$get();
 
-    expect(response.ok).toBe(true);
-    expect(response.status).toBe(200);
-
-    const json = await response.json();
-
-    expect(json).toBeDefined();
-    expect(json).toBeInstanceOf(Array);
-    expect(json).toHaveLength(0);
+    expect(receivedError).toMatchObject({
+      message: 'No `token` option is allowed',
+    });
   });
 });


### PR DESCRIPTION
This change ensures that the `token` config option is no longer allowed to be defined at all. Previously, we were ignoring the option and logging a message, which is not ideal.