### PR TITLE
Expose Hono context to options callback

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -4,13 +4,13 @@ import { createFactory } from 'hono/factory';
 import { testClient } from 'hono/testing';
 
 import { ronin } from '@/src/index';
+import { fetcher } from '@/tests/utils';
 
 import type { Bindings, Variables } from '@/src/index';
-import { fetcher } from '@/tests/utils';
 
 import.meta.env.RONIN_TOKEN = 'secret-token';
 
-describe('use `ronin` middleware', () => {
+describe('Use `ronin` middleware', () => {
   const factory = createFactory<{ Bindings: Bindings; Variables: Variables }>();
 
   it('with default options', async () => {
@@ -128,7 +128,55 @@ describe('use `ronin` middleware', () => {
     expect(json).toHaveLength(1);
   });
 
-  it('with a missing `RONIN_TOKEN`', async () => {
+  it('with custom options using the Hono context (function)', async () => {
+    const app = factory
+      .createApp()
+      .use(
+        '*',
+        ronin((context) => {
+          expect(context).toBeDefined();
+          expect(context.env).toMatchObject({});
+
+          return {
+            asyncContext: new AsyncLocalStorage(),
+            fetch: fetcher,
+            hooks: {
+              user: {
+                beforeGet: (query) => {
+                  query.limitedTo = 1;
+                  return query;
+                },
+              },
+            },
+          };
+        }),
+      )
+      .get('/', async (c) => {
+        expect(c.var.ronin).toBeDefined();
+
+        const users = await c.var.ronin.get.users();
+
+        expect(users).toBeDefined();
+        expect(users).toBeInstanceOf(Array);
+
+        return c.json(users);
+      });
+
+    const response = await testClient(app, {
+      RONIN_TOKEN: import.meta.env.RONIN_TOKEN,
+    }).index.$get();
+
+    expect(response.ok).toBe(true);
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+
+    expect(json).toBeDefined();
+    expect(json).toBeInstanceOf(Array);
+    expect(json).toHaveLength(1);
+  });
+
+  it('with a missing RONIN token', async () => {
     let receivedError: Error | undefined;
 
     const app = factory
@@ -152,16 +200,23 @@ describe('use `ronin` middleware', () => {
 
     expect(receivedError).toMatchObject({
       message:
-        'A `RONIN_TOKEN` environment variable must be provided for the RONIN middleware',
+        'Either a `RONIN_TOKEN` environment variable or a `token` option must be provided for the RONIN middleware',
     });
   });
 
-  it('with a `token` option', async () => {
+  it('with a `null` RONIN token', async () => {
     let receivedError: Error | undefined;
 
     const app = factory
       .createApp()
-      .use('*', ronin({ fetch: fetcher, token: crypto.randomUUID() }))
+      .use(
+        '*',
+        ronin({
+          fetch: fetcher,
+          // @ts-expect-error `null` is not allowed here.
+          token: null,
+        }),
+      )
       .get('/', async (c) => {
         expect(c.var.ronin).toBeDefined();
 
@@ -175,11 +230,12 @@ describe('use `ronin` middleware', () => {
       });
 
     await testClient(app, {
-      RONIN_TOKEN: import.meta.env.RONIN_TOKEN,
+      RONIN_TOKEN: null,
     }).index.$get();
 
     expect(receivedError).toMatchObject({
-      message: 'The RONIN middleware does not support a `token` option',
+      message:
+        'Either a `RONIN_TOKEN` environment variable or a `token` option must be provided for the RONIN middleware',
     });
   });
 });


### PR DESCRIPTION
Currently you can use a callback function to create the options for this Hono middleware, the Hono request context is not exposed & shared such that you could, for example, access the Hono context environment variables to set the `token` property to something else.

With this PR that issue is now fixed along with some minor refactoring & the updating of any tests affected.

### Example
```ts
import { Hono } from "hono";
import { ronin } from "@ronin/hono";

const app = new Hono();

app.use("*", ronin(
	(c) => ({
		token: c.env.YOUR_TOKEN_NAME,
	})
));

app.get("/", async (c) => {
  const posts = await c.var.ronin.get.posts();
  return c.json(posts);
});
```